### PR TITLE
Add Lua cflags from deps/Makefile

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,6 +68,10 @@ pub fn build(b: *std.build.Builder) void {
         "deps/lua/src/strbuf.c",
     }, &.{
         "-std=c99",
+        "-Wall",
+        "-DLUA_ANSI",
+        "-DENABLE_CJSON_GLOBAL",
+        "-DLUA_USE_MKSTEMP",
     });
 
     const redis_cli = b.addExecutable("redis-cli", null);


### PR DESCRIPTION
The Makefile chain for Lua goes Makefile -> src/Makefile -> deps/Makefile -> deps/lua/Makefile. The deps/Makefile part was missed during the stream, so these Lua cflags were also missed.

https://github.com/kristoff-it/redis/blob/3cf2b35a507a8c166c8fe3ee5b1266c1f61fee0e/deps/Makefile#L72

(this is probably the Makefile you were thinking of @kristoff-it)